### PR TITLE
Move chai and mocha to .devDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     { "type" : "git",
       "url" : "https://github.com/claudioc/jingo"
     },
-  "directories" : { "lib" : "./lib/" },  
+  "directories" : { "lib" : "./lib/" },
   "dependencies": {
     "express": "3.x",
     "jade": "*",
@@ -23,8 +23,14 @@
     "gravatar": ">= 1.0.6",
     "express-validator": ">= 0.3.0",
     "commander": "*",
-    "yaml": "*",
-    "chai": "*"
+    "yaml": "*"
+  },
+  "devDependencies": {
+    "chai": "*",
+    "mocha": "*"
+  },
+  "scripts": {
+    "test": "mocha test/spec"
   },
   "engines": {
     "node": "0.8.x",
@@ -34,5 +40,5 @@
    [ { "type" : "MIT"
      , "url" : "http://github.com/claudioc/jingo/raw/master/LICENSE"
     }
-   ]  
+   ]
 }

--- a/test/README.md
+++ b/test/README.md
@@ -1,4 +1,0 @@
-npm install -g mocha
-http://chaijs.com/api/bdd/
-
-run tests with "mocha test/spec"


### PR DESCRIPTION
Since chai is only used in testing, it's best to list it as a [dev dependency](https://npmjs.org/doc/json.html#devDependencies). Also, I made mocha listed as a dev dependency as well. Finally, instead of having to run `mocha test/spec` every time you want to test, you can instead use `npm test` (see [npm scripts](https://npmjs.org/doc/scripts.html))
