### PR TITLE
Properly handle newlines and missing titles

### DIFF
--- a/lib/tools.js
+++ b/lib/tools.js
@@ -2,6 +2,26 @@ var Crypto = require('crypto');
 
 var tools = {
 
+  hasTitle: function(content) {
+    var title = content.split("\n")[0];
+
+    return title.charAt(0)=="#" ? true : false;
+  },
+
+  getPageTitle: function(content, page) {
+    var title = content.split("\n")[0];
+    title = this.hasTitle(content) ? title.substr(1) : page.replace(".md", "");
+
+    return title;
+  },
+
+  getContent: function(content) {
+    var pageRows = content.split("\n");
+    content = this.hasTitle(content) ? content.substr(pageRows[0].length) : content;
+
+    return content;
+  },
+
   isAuthorized: function(email, pattern) {
 
     if (!email || email.trim() == "") {

--- a/routes/index.js
+++ b/routes/index.js
@@ -86,7 +86,7 @@ exports.pageList = function(req, res) {
               });
             }
           });
-        })(content.split("\n")[0].substr(1));
+        })(Tools.getPageTitle(content, page));
       });
     });
   });
@@ -128,9 +128,9 @@ exports.pageShow = function(req, res) {
         delete req.session.notice;
 
         res.render('show', {
-          title:   app.locals.appTitle + " – " + content.split("\n")[0].substr(1),
-          content: Renderer.render(content),
-          pageName: pageName,
+          title:   app.locals.appTitle + " – " + Tools.getPageTitle(content, pageName),
+          content: Tools.hasTitle(content) ? Renderer.render(content) : Renderer.render("# " + pageName + "\n" + content),
+          pageName: pageName, 
           metadata: metadata
         });
 
@@ -204,7 +204,6 @@ exports.pageCreate = function(req, res) {
 exports.pageEdit = function(req, res) {
 
   var pageName = res.locals.pageName = req.params.page
-    , pageRows
     , lock;
 
   if (lock = Locker.getLock(pageName)) {
@@ -226,12 +225,10 @@ exports.pageEdit = function(req, res) {
         res.redirect('/pages/new/' + pageName);
       } else {
 
-        pageRows = content.split("\n");
-
         if (!req.session.formData) {
           res.locals.formData = {
-            pageTitle: pageRows[0].substr(1),
-            content: content.substr(pageRows[0].length)
+            pageTitle: Tools.getPageTitle(content, pageName),
+            content: Tools.getContent(content)
           };
         } else {
           res.locals.formData = req.session.formData;
@@ -420,7 +417,7 @@ exports.pageHistory = function(req, res) {
     if (err) { res.redirect('/'); }
 
     Git.log(pageName + ".md", "HEAD", 30, function(err, metadata) {
-      res.locals.pageTitle = content.split("\n")[0].substr(1);
+      res.locals.pageTitle = Tools.getPageTitle(content, pageName);
       res.locals.pageName = pageName;
       res.locals.items = metadata;
       res.render('history', {


### PR DESCRIPTION
Textareas can return their content with DOS-style `\r\n` line endings. This happens in Chrome on OSX, among many other browsers and platforms. This makes the `.md` files rather cumbersome to work with in vim and other tools.

When editing, jingo currently splits the file content on `\n` newlines and then joins them again to a single blob. This loses existing newline data for `.md` files which use `\n`-style line endings, which happens to be most of them. Try editing README.md for an example. 

This commit converts all line endings to `\n` on creation or the next edit of an existing file, preserving all newlines. It also allows jingo to properly edit existing Unix-style markdown files by less-destructively reading the file input.

The 2 followup commits allow you to add other markdown files without proper titles to jingo, as in the case of migrating from gollum. This is accomplished by checking for a jingo-formatted title line, making sure the first line of content does not get clobbered when editing, and using the filename for a title where appropriate. Subsequent edits prepend the jingo-formatted title to the file if necessary while staying compatible with other tools.
