### PR TITLE
Make authorization.validMatches work as expected.

### DIFF
--- a/routes/auth.js
+++ b/routes/auth.js
@@ -87,7 +87,7 @@ function _getAuthDone(req, res) {
     return;
   }
 
-  if (!auth.alone.used && !tools.isAuthorized(res.locals.user.email, auth.validMatches)) {
+  if (!auth.alone.used && !tools.isAuthorized(res.locals.user.email, app.locals.config.get("authorization").validMatches)) {
     req.logout();
     req.session = null;
     res.statusCode = 403;


### PR DESCRIPTION
A small error in routes/auth.js results in tools.isAuthorized() always being called with the second argument undefined, which effectively will validate anyone regardless of the setting of validMatches in the config file.

This PR fixes that.
