### PR TITLE
Support case insensitive document title search.

### DIFF
--- a/lib/gitmech.js
+++ b/lib/gitmech.js
@@ -345,11 +345,16 @@ var gitMech = {
       }
 
       // Search in the file names
-      gitSpawn([ "ls-files", docSubdir + "*" + pattern + "*.md" ], function(err, data) {
+      gitSpawn([ "ls-files", docSubdir + "*.md" ], function(err, data) {
 
         if (data) {
+          var patternLower = pattern.toLowerCase();
+
           data.toString().split("\n").forEach(function(name) {
-            result.push(path.basename(name));
+            var nameLower = path.basename(name).toLowerCase();
+            if (nameLower.search(patternLower) >= 0) {
+              result.push(path.basename(name));
+            }
           });
         }
 


### PR DESCRIPTION
The current master only supports case sensitive filename search. This PR fixes that by comparing after toLowerCase().

toLowerCase() will propably not solve this for the complete UTF-8 space, but it's much better than current case sensitive matching.
