### PR TITLE
Fix .md table pipe parsing

### DIFF
--- a/lib/renderer.js
+++ b/lib/renderer.js
@@ -61,6 +61,8 @@ function extractTags(text) {
 
   tagmap = {};
 
+  text = text.replace(/\|/g, " | "); // Spaces provide easier parsing of .md table pipes
+  
   var matches = text.match(/(.?)\[\[(.+?)\]\]([^\[]?)/g),
       tag,
       id;


### PR DESCRIPTION
The regex that populates "matches" gets confused when a markdown table pipe ("|") is directly followed by a markdown double bracket link tag ("[[").   Inserting spaces around the pipe allows the regex to parse the markdown text properly.

ex: | column 1 | column 2 |[[link]]|  // The link will work but it will be mistakenly rendered as part of column 2 in the HTML output.

It would be more elegant to fix the regex, but I couldn't figure out the right expression. I used this work-around instead.  
