### PR TITLE
Option to enable/disable GFM line breaks

### DIFF
--- a/README.md
+++ b/README.md
@@ -233,6 +233,10 @@ Configuration options reference
 
   With this option you can revert this decision if for some reason your documents are not rendered how you like.
 
+####application.gfmBreaks
+
+  Enable [GFM line breaks](https://help.github.com/articles/github-flavored-markdown#newlines) (defaults to `true`).
+
 ####authentication.staticWhitelist
 
   This is to enable jingo to serve any kind of static file (like images) from the repository. By default, Jingo will serve `*.md` files and `*.jpg, *.png, *.gif`. Provide the values as a comma separated list of regular expressions.

--- a/lib/config.js
+++ b/lib/config.js
@@ -58,6 +58,7 @@ module.exports = (function() {
         skipGitCheck: false,
         loggingMode: 1,
         pedanticMarkdown: true,
+        gfmBreaks: true,
         staticWhitelist: "/\\.png$/i, /\\.jpg$/i, /\\.gif$/i"
       },
 

--- a/lib/renderer.js
+++ b/lib/renderer.js
@@ -43,8 +43,8 @@ Marked.setOptions({
   gfm: true,
   renderer: mdRenderer,
   // pedantic: this is set on the render method
+  // breaks: this is set on the render method
   tables: true,
-  breaks: true,
   smartLists: true,
   sanitize: false, // To be able to add iframes
   highlight: function(code, lang) {
@@ -111,7 +111,10 @@ var Renderer = {
 
   render: function(content) {
 
-    Marked.setOptions({ pedantic: configuration.getConfig().application.pedanticMarkdown });
+    Marked.setOptions({
+        pedantic: configuration.getConfig().application.pedanticMarkdown,
+        breaks: configuration.getConfig().application.gfmBreaks
+    });
 
     var text = extractTags(content);
     text = evalTags(text);


### PR DESCRIPTION
This PR adds an option to enable or disable [GFM line breaks](https://help.github.com/articles/github-flavored-markdown#newlines) in the Markdown parser.

Many people (myself including) like most features of GFM, but not its line break policy. For instance, I use Jingo as my personal wiki for academic papers. The content I put there is mostly automatically converted LaTeX (or manually written text with LaTeX embeddings). When I write LaTeX, I usually start each sentence from a new line, because **(a)** it greatly simplifies diffing and merging of plain text in Git, and **(b)** LaTeX doesn't care about line breaks. With Markdown, I can keep the same behavior if GFM line breaks are disabled.