### PR TITLE
fixed cookie name to be RTC 6265 compliant

### DIFF
--- a/lib/app.js
+++ b/lib/app.js
@@ -117,7 +117,11 @@ module.exports.initialize = function(config) {
 
   app.use(express.static(path.join(__dirname + "/../", 'public')));
   app.use(cookieParser());
-  app.use(cookieSession({ keys: ["jingo"], cookie: { maxAge: 30 * 24 * 60 * 60 * 1000 }}));
+  app.use(cookieSession({
+    name: "JingoSession",
+    keys: ["jingo"],
+    cookie: { maxAge: 30 * 24 * 60 * 60 * 1000 }
+  }));
   app.use(session({ name: "jingosid",
                     secret: config.get("application").secret,
                     cookie: { httpOnly: true },


### PR DESCRIPTION
The default cookie name ("express:sess") that the cookie-session module generates is not compliant with RFC 6265, and results in rejected requests if the other web app is checking for validity.

Therefore I changed the cookie name to a compliant one.