### PR TITLE
Fix image bleed

### DIFF
--- a/public/css/style.css
+++ b/public/css/style.css
@@ -39,6 +39,12 @@ p.user {
   overflow: hidden;
 }
 
+#content img {
+  display: block;
+  max-width: 100%;
+  height: auto;
+}
+
 #content.show li {
   line-height: 1.92;
 }


### PR DESCRIPTION
Large images in the `#content` box weren't restricted to the width of the box, causing them to disappear behind the right border of the `#content` box.