### PR TITLE
Fixes GitHub auth with a new config param

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,5 @@ node_modules/*
 config.yaml
 config.yml
 data/*
+*.iml
+.idea

--- a/README.md
+++ b/README.md
@@ -261,7 +261,7 @@ Configuration options reference
 
 #### authentication.github.clientId
 #### authentication.github.clientSecret
-#### authentication.github.callbackBaseURL
+#### authentication.github.callbackUrl
 
   Values required for GitHub OAuth2 authentication. Refer to a previous section of this document on how to set them up.
 

--- a/README.md
+++ b/README.md
@@ -127,8 +127,8 @@ For GitHub, follow these instructions (you need to be logged in in GitHub):
 * Enter your installation URL (localhost is OK, for example "http://localhost:6767/")
 * Enter <your installation URL>/auth/github/callback as the `Authorization callback URL`
 * Press the `Register application` button
-* In the following page, on the top right corner, take note of the values for `Client ID` and `Client Secret`
-* Now you need to copy the `Client ID` and `Client secret` in your jingo config file in the proper places
+* In the following page, on the top right corner, take note of the values for `Client ID`, `Client Secret` and `Authorization callback URL`
+* Now you need to copy the `Client ID`, `Client secret` and `callbackUrl` in your jingo config file in the proper places
 
 The _local_ method uses an array of `username`, `passwordHash` and optionally an `email`. The password is hashed using a _non salted_ SHA-1 algorithm, which makes this method not the safest in the world but at least you don't have a clear text password in the config file. To generate the hash, use the `--hash-string` program option: once you get the hash, copy it in the config file.
 
@@ -261,6 +261,7 @@ Configuration options reference
 
 #### authentication.github.clientId
 #### authentication.github.clientSecret
+#### authentication.github.callbackBaseURL
 
   Values required for GitHub OAuth2 authentication. Refer to a previous section of this document on how to set them up.
 

--- a/lib/app.js
+++ b/lib/app.js
@@ -19,7 +19,7 @@ var express        = require("express"),
     expValidator   = require("express-validator"),
     cookieParser   = require("cookie-parser"),
     logger         = require("morgan"),
-    program = require('commander'),
+    program        = require('commander'),
     cookieSession  = require("cookie-session"),
     gravatar       = require("gravatar"),
     passport       = require("passport"),
@@ -31,7 +31,7 @@ var app;
 
 module.exports.getInstance = function() {
   if (!app) {
-    throw new Error("Cannot get an instance of an unitialized App");
+    throw new Error("Cannot get an instance of an uninitialized App");
   }
   return app;
 };

--- a/lib/config.js
+++ b/lib/config.js
@@ -71,7 +71,8 @@ module.exports = (function() {
         github: {
           enabled: false,
           clientId: "replace me with the real value",
-          clientSecret: "replace me with the real value"
+          clientSecret: "replace me with the real value",
+          callbackUrl: "replace with full callback URL including /auth/github/callback"
         },
         // @deprecated, use local with just an user
         alone: {

--- a/routes/auth.js
+++ b/routes/auth.js
@@ -51,7 +51,7 @@ if (auth.github.enabled) {
   passport.use(new passportGithub({
       clientID: auth.github.clientId,
       clientSecret: auth.github.clientSecret,
-      callbackURL: app.locals.baseUrl + '/auth/github/callback'
+      callbackURL: auth.github.callbackUrl
     },
     function(accessToken, refreshToken, profile, done) {
       usedAuthentication("github");

--- a/views/layout.jade
+++ b/views/layout.jade
@@ -59,7 +59,7 @@ html
           .col-md-8.with-footer
             .content !{_footer}
 
-    script(src="http://ajax.googleapis.com/ajax/libs/jquery/1/jquery.min.js")
+    script(src="https://ajax.googleapis.com/ajax/libs/jquery/1/jquery.min.js")
     script.
       window.jQuery || document.write("<sc" + "ript src='/vendor/jquery.min.js'></scr" + "ipt>");
     script(src="/vendor/bootstrap/js/bootstrap.min.js")


### PR DESCRIPTION
introduces authentication.github.callbackUrl parameter for GitHub authentication. This way server.baseUrl is not used anymore for real.

Related to issue #104 

Cheers!