### PR TITLE
Add an API version of the rendered output.

### DIFF
--- a/lib/app.js
+++ b/lib/app.js
@@ -179,6 +179,16 @@ module.exports.initialize = function(config) {
 
   app.use("/wiki", wikiStatic.configure());
 
+  function allowCrossDomain(req, res, next) {
+    res.header('Access-Control-Allow-Origin', '*');
+    res.header('Access-Control-Allow-Methods', '*');
+    res.header('Access-Control-Allow-Headers', '*');
+    next();
+  }
+
+  app.use(allowCrossDomain);
+  app.use(require("../routes/api"))
+
   app.use(require("../routes/wiki"))
      .use(require("../routes/pages"))
      .use(require("../routes/search"))

--- a/routes/api.js
+++ b/routes/api.js
@@ -1,0 +1,64 @@
+var router = require("express").Router(),
+    tools  = require("../lib/tools"),
+    path = require("path"),
+    renderer = require('../lib/renderer'),
+    models = require("../lib/models"),
+    app    = require("../lib/app").getInstance(),
+    Promise = require("bluebird");
+
+models.use(Git);
+
+router.get("/api/:page", _getApiWikiPage);
+
+function _getApiWikiPage(req, res) {
+  var page = new models.Page(req.params.page, req.params.version);
+
+  page.fetch().then(function() {
+
+    if (!page.error) {
+
+      res.locals.canEdit = true;
+      if (page.revision != "HEAD") {
+        res.locals.warning = "You're not reading the latest revision of this page, which is " + "<a href='" + page.urlForShow() + "'>here</a>.";
+        res.locals.canEdit = false;
+      }
+
+      res.locals.notice = req.session.notice;
+      delete req.session.notice;
+
+      res.render("api_show", {
+        page: page,
+        title: app.locals.config.get("application").title + " – " + page.title,
+        content: renderer.render("# " + page.title + "\n" + page.content)
+      });
+    }
+    else {
+
+      if (req.user) {
+
+        // Try sorting out redirect loops with case insentive fs
+        // Path 'xxxxx.md' exists on disk, but not in 'HEAD'.
+        if (/but not in 'HEAD'/.test(page.error)) {
+          page.setNames(page.name.slice(0,1).toUpperCase() + page.name.slice(1));
+        }
+        res.redirect(page.urlFor("new"));
+      } else {
+
+        // Special case for the index page, anonymous user and an empty docbase
+        if (page.isIndex()) {
+          res.render("welcome", {
+            title: "Welcome to " + app.locals.config.get("application").title
+          });
+        }
+        else {
+          res.locals.title = "404 - Not found";
+          res.statusCode = 404;
+          res.render('404.jade');
+          return;
+        }
+      }
+    }
+  });
+}
+
+module.exports = router;

--- a/views/api_show.jade
+++ b/views/api_show.jade
@@ -1,0 +1,16 @@
+include mixins/form
+
+block content
+
+  #content.show
+    mixin notice()
+    mixin warning()
+    !=content
+
+  p.footer Updated by&nbsp;
+    if page.metadata.email
+      img(src=gravatar().url("#{page.metadata.email}", {s:16}))
+    b  #{page.metadata.author}
+    |,&nbsp;
+    b(title="#{page.metadata.date}") #{page.metadata.relDate}&nbsp;
+    | &ndash; #{page.metadata.hash}


### PR DESCRIPTION
I happen to have a use case where I'd like to use the Jingo interface to maintain my wiki contents, however, for my API's audience, I'd like to embed the pages directly into another web application that I already have.  For this purpose I'd like to basically expose the page retrieval/rendering part of the application as an API.  This API would do the same as the standard `/wiki/:page` route, however leave out the layout and toolbar parts.

Then I can call the API and load another `div` in my other application with the result, skin with some CSS and now I've got the wiki pages in my app.

I can edit the pages, live, in the usual way also...best of both worlds.

I don't know if anyone else has the same needs as I do, but I figure I could post my PR, just in case.