### PR TITLE
Generate Table of Contents

### DIFF
--- a/lib/renderer.js
+++ b/lib/renderer.js
@@ -2,7 +2,8 @@ var Marked = require("marked"),
     crypto = require("crypto"),
     Nsh    = require("node-syntaxhighlighter"),
     namer  = require("../lib/namer"),
-    Configurable = require("./configurable");
+    Configurable = require("./configurable"),
+    reTOC = /(.?)\[\(TOC\)\](.?)/g;
 
 var Configuration = function() {
   Configurable.call(this);
@@ -39,6 +40,14 @@ mdRenderer.code = function(code, lang, escaped) {
 
 };
 
+function escapeHeading(text) {
+  return text.trim().toLowerCase().replace(/[^\w]+/g, '-');
+}
+
+mdRenderer.heading = function(text, level) {
+  return '<h' + level + ' id="heading-' + escapeHeading(text) + '">' + text + '</h' + level + '>';
+};
+
 Marked.setOptions({
   gfm: true,
   renderer: mdRenderer,
@@ -54,6 +63,7 @@ Marked.setOptions({
 });
 
 var tagmap = {};
+var includeTOC = false;
 
 // Yields the content with the rendered [[bracket tags]]
 // The rules are the same for Gollum https://github.com/github/gollum
@@ -78,6 +88,9 @@ function extractTags(text) {
     });
 
   }
+
+  includeTOC = reTOC.test(text);
+
   return text;
 }
 
@@ -102,6 +115,30 @@ function evalTags(text) {
   for (k in tagmap) {
     re = new RegExp(k, "g");
     text = text.replace(re, tagmap[k]);
+  }
+
+  text = generateTOC(text);
+
+  return text;
+}
+
+function generateTOC(text) {
+  var links = [];
+  if (includeTOC) {
+    headings = text.match(new RegExp(Marked.Lexer.rules.heading.source, "gm"));
+    if (headings.length) {
+      for (var i = 0, l= headings.length; i < l; i++) {
+        var heading = headings[i].trim();
+        var tag = (new RegExp(Marked.Lexer.rules.heading.source)).exec(heading);
+        if (2 < tag.length) {
+          if (1 < tag[1].length) { // Don't include H1 tags in TOC
+            links.push('<li><a href="#heading-' + escapeHeading(tag[2]) + '">' + tag[2].trim() + '</a></li>');
+          }
+        }
+      }
+    }
+    var toc='<div class="toc"><span class="toc-heading">Table of Contents</span><ul>' + links.join('') + '</ul></div>';
+    text = text.replace(reTOC, toc);
   }
 
   return text;

--- a/public/css/style.css
+++ b/public/css/style.css
@@ -115,6 +115,7 @@ dl.search-results dt {
   font-size: 120%;
 }
 
+.toc-heading,
 h2,
 h1 {
   border-bottom: 1px solid #ddd;
@@ -126,6 +127,7 @@ h1 {
   font-size: 32px;
 }
 
+.toc-heading,
 h2 {
   font-size: 24px;
 }


### PR DESCRIPTION
Automatically generate a table of contents on the page using `[(TOC)]`.

This will find all heading tags `h2` to `h6` and create a table of contents. `h1` is usually the page heading so it is ignored.