### PR TITLE
Added support for {{<directive>}} directives such as table of contents.

### DIFF
--- a/lib/directives.js
+++ b/lib/directives.js
@@ -1,0 +1,10 @@
+var directives = {
+  TOC: function(text) {
+    var toc = require('markdown-toc');
+    return toc(text).content;
+  }
+};
+
+module.exports = {
+  directiveMap: directives
+};

--- a/lib/renderer.js
+++ b/lib/renderer.js
@@ -2,6 +2,7 @@ var Marked = require("marked"),
     crypto = require("crypto"),
     Nsh    = require("node-syntaxhighlighter"),
     namer  = require("../lib/namer"),
+    directives   = require("../lib/directives"),
     Configurable = require("./configurable");
 
 var Configuration = function() {
@@ -107,6 +108,25 @@ function evalTags(text) {
   return text;
 }
 
+var directiveMap = directives.directiveMap;
+
+function applyDirectives(text) {
+  var matches = text.match(/(.?)\{\{((.+?|(.*[\s\S].*)+?))\}\}/g);
+
+  if (matches) {
+    matches.forEach(function(match) {
+      var directiveString = /\{\{((.+?|(.*[\s\S].*)+?))\}\}/.exec(match)[1];
+      var directiveSplit = directiveString.split('\n');
+      var directive = directiveSplit[0];
+      var args = directiveSplit.slice(1).join('\n');
+      if (directive in directiveMap) {
+        text = text.replace(match, directiveMap[directive](text, args));
+      }
+    });
+  }
+  return text;
+}
+
 var Renderer = {
 
   render: function(content) {
@@ -118,6 +138,7 @@ var Renderer = {
 
     var text = extractTags(content);
     text = evalTags(text);
+    text = applyDirectives(text);
     return Marked(text);
   }
 

--- a/lib/renderer.js
+++ b/lib/renderer.js
@@ -111,11 +111,11 @@ function evalTags(text) {
 var directiveMap = directives.directiveMap;
 
 function applyDirectives(text) {
-  var matches = text.match(/(.?)\{\{(([^\}]+?|([^\}]*[\s\S][^\}]*)+?))\}\}/g);
+  var matches = text.match(/\{\{([^}]*)\}\}/g);
 
   if (matches) {
     matches.forEach(function(match) {
-      var directiveString = /\{\{((.+?|(.*[\s\S].*)+?))\}\}/.exec(match)[1];
+      var directiveString = /\{\{([^}]*)\}\}/.exec(match)[1];
       var directiveSplit = directiveString.split('\n');
       var directive = directiveSplit[0];
       var args = directiveSplit.slice(1).join('\n');

--- a/lib/renderer.js
+++ b/lib/renderer.js
@@ -111,7 +111,7 @@ function evalTags(text) {
 var directiveMap = directives.directiveMap;
 
 function applyDirectives(text) {
-  var matches = text.match(/(.?)\{\{((.+?|(.*[\s\S].*)+?))\}\}/g);
+  var matches = text.match(/(.?)\{\{(([^\}]+?|([^\}]*[\s\S][^\}]*)+?))\}\}/g);
 
   if (matches) {
     matches.forEach(function(match) {

--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
     "jade": "*",
     "js-yaml": "^3.1.0",
     "lodash": "^2.4.1",
+    "markdown-toc": "^0.11.7",
     "marked": "^0.3.5",
     "method-override": "^2.3.0",
     "morgan": "^1.5.0",

--- a/test/spec/rendererSpec.js
+++ b/test/spec/rendererSpec.js
@@ -38,5 +38,10 @@ describe ("Renderer", function() {
     expect(Renderer.render(text)).to.be.equal("<p>a <a class=\"internal\" href=\"/wiki/Foo-%2B-Bar\">Foo / Bar</a> b</p>\n");
   });
 
+  it ("should replace {{TOC}} with the table of contents", function() {
+    var text = "{{TOC}}\n\n # Heading 1 \n\n This is some text";
+    expect(Renderer.render(text)).to.be.equal("<ul>\n<li><p><a href=\"#heading-1\">Heading 1</a></p>\n<h1 id=\"heading-1\">Heading 1</h1>\n<p>This is some text</p>\n</li>\n</ul>\n");
+  });
+
 
 });


### PR DESCRIPTION
I added a function `applyDirectives` which looks for `{{.*}}` including newlines. It then replaces the `{{.*}}` match with the return of functions from `directives.js`. As an example:

If the wiki text is: 

    {{sequence
    
    A->B: something
    }}

Then `applyDirectives` will pass the full text of the wiki and `A->B: something` respectively to the function `directives.directiveMap.sequence`. The return of this function will replace the braced text.