### PR TITLE
Ability to add heading fragments

### DIFF
--- a/lib/config.js
+++ b/lib/config.js
@@ -40,7 +40,7 @@ module.exports = (function() {
 
       return true;
     },
-    
+
     getError: function() {
       return error;
     },
@@ -92,7 +92,8 @@ module.exports = (function() {
 
       features: {
         markitup: false,
-        codemirror: true
+        codemirror: true,
+        fragments: true
       },
 
       server: {
@@ -115,7 +116,7 @@ module.exports = (function() {
       // For example, if the index subkey is not present the default
       // would be Home, not home.
 
-      // Please note that the combination of "from filename" and "ascii only" 
+      // Please note that the combination of "from filename" and "ascii only"
       // is not really an valid option (information will be probably lost regarding
       // non ASCII only caracters)
       pages: {
@@ -172,7 +173,7 @@ module.exports = (function() {
       if (config.authentication.alone.enabled) {
         console.warn("Deprecation: Alone authentication is deprecated and should be changed with Local.");
       }
-      
+
       config.features = _.extend({}, this.defaults.features, config.features);
 
       // For backward compatibility with version < 0.5, we set markitup as the

--- a/lib/renderer.js
+++ b/lib/renderer.js
@@ -7,7 +7,7 @@ var Marked = require("marked"),
 
 var Configuration = function() {
   Configurable.call(this);
-}
+};
 
 Configuration.prototype = Object.create(Configurable.prototype);
 
@@ -127,6 +127,32 @@ function applyDirectives(text) {
   return text;
 }
 
+function addHeadingFragments(text) {
+  if (configuration.getConfig().features.fragments) {
+    var reHeading = new RegExp(Marked.Lexer.rules.heading.source, 'gm'),
+        matches = text.match(reHeading);
+
+    if (matches) {
+      /*
+        Optional : uncomment to remove page name fragment
+      */
+      /* matches.shift(); */
+      matches.forEach(function(match) {
+        var headingParts = Marked.Lexer.rules.heading.exec(match);
+        if (2 < headingParts.length) {
+          var headingLevel = headingParts[1],
+              headingText = headingParts[2],
+              safeHeading = namer.wikify(headingText).toLowerCase(),
+              insertion = "<div class=\"headingFragment\"><a href=\"#" + safeHeading + "\" aria-hidden=\"true\"><span class=\"icon ion-link\"></span></a></div>\n\n";
+          text = text.replace(match, headingLevel + " " + headingText + " " + headingLevel + "\n" + insertion);
+        }
+      });
+    }
+  }
+
+  return text;
+}
+
 var Renderer = {
 
   render: function(content) {
@@ -139,6 +165,7 @@ var Renderer = {
     var text = extractTags(content);
     text = evalTags(text);
     text = applyDirectives(text);
+    text = addHeadingFragments(text);
     return Marked(text);
   }
 

--- a/public/css/style.css
+++ b/public/css/style.css
@@ -132,9 +132,6 @@ h2 {
 
 h3 {
   font-size: 18px;
-}
-
-h3 {
   margin: 0 0 10px 0;
 }
 
@@ -143,6 +140,72 @@ h2 a, h2 a:hover,
 h3 a, h3 a:hover,
 h4 a, h4 a:hover {
   color: inherit;
+}
+
+/*
+  Fix Navbar floating over top of heading
+ */
+h1:before,
+h2:before,
+h3:before,
+h4:before,
+h5:before,
+h6:before {
+  display: block;
+  content: " ";
+  margin-top: -50px;
+  height: 50px;
+  visibility: hidden;
+}
+
+/*
+  Default styles for heading fragment (h6)
+ */
+.headingFragment {
+  float: left;
+  line-height: 1;
+  font-size: 20px;
+  position: relative;
+  left: -22px;
+  top: -25px;
+}
+
+/*
+  Hide heading fragment until heading or fragment is hovered
+ */
+.headingFragment a {
+  position: relative;
+  visibility: hidden;
+}
+
+/*
+  Show fragment on hover
+ */
+h1:hover + .headingFragment a,
+h2:hover + .headingFragment a,
+h3:hover + .headingFragment a,
+h4:hover + .headingFragment a,
+h5:hover + .headingFragment a,
+h6:hover + .headingFragment a,
+.headingFragment:hover a {
+  visibility: visible;
+}
+
+/*
+  Set offsets based on font-size
+ */
+h1 + .headingFragment {
+  top: -46px;
+}
+h2 + .headingFragment {
+  top: -44px;
+}
+h3 + .headingFragment,
+h4 + .headingFragment {
+  top: -28px;
+}
+h5 + .headingFragment {
+  top: -27px;
 }
 
 hr {

--- a/public/css/style.css
+++ b/public/css/style.css
@@ -168,6 +168,7 @@ h6:before {
   position: relative;
   left: -22px;
   top: -25px;
+  display: none;
 }
 
 /*
@@ -704,5 +705,9 @@ a.btn-auth:hover {
   .tools-handle {
     top: 41px;
     left: 60%;
+  }
+
+  .headingFragment {
+    display: block;
   }
 }


### PR DESCRIPTION
Fixes issue #13.

Not sure if there may be a better way of doing this. The problem is the regex for the headings expects the heading to be on a line by itself.