### PR TITLE
Add config option for oauth redirect

### DIFF
--- a/lib/config.js
+++ b/lib/config.js
@@ -66,12 +66,14 @@ module.exports = (function() {
         google: {
           enabled: true,
           clientId: "replace me with the real value",
-          clientSecret: "replace me with the real value"
+          clientSecret: "replace me with the real value",
+          redirectURL: ""
         },
         github: {
           enabled: false,
           clientId: "replace me with the real value",
-          clientSecret: "replace me with the real value"
+          clientSecret: "replace me with the real value",
+          redirectURL: ""
         },
         // @deprecated, use local with just an user
         alone: {

--- a/routes/auth.js
+++ b/routes/auth.js
@@ -29,12 +29,13 @@ router.get("/auth/github/callback", passport.authenticate('github', {
 }));
 
 if (auth.google.enabled) {
+  var redirectURL = auth.google.redirectURL || app.locals.baseUrl + '/oauth2callback';
   passport.use(new passportGoogle.OAuth2Strategy({
       clientID: auth.google.clientId,
       clientSecret: auth.google.clientSecret,
       // I will leave the horrible name as the default to make the painful creation
       // of the client id/secret simpler
-      callbackURL: app.locals.baseUrl + '/oauth2callback'
+      callbackURL: redirectURL
     },
 
     function(accessToken, refreshToken, profile, done) {
@@ -45,13 +46,14 @@ if (auth.google.enabled) {
 }
 
 if (auth.github.enabled) {
+  var redirectURL = auth.github.redirectURL || app.locals.baseUrl + '/auth/github/callback';
 
   // Register a new Application with Github https://github.com/settings/applications/new
   // Authorization callback URL /auth/github/callback
   passport.use(new passportGithub({
       clientID: auth.github.clientId,
       clientSecret: auth.github.clientSecret,
-      callbackURL: app.locals.baseUrl + '/auth/github/callback'
+      callbackURL: redirectURL
     },
     function(accessToken, refreshToken, profile, done) {
       usedAuthentication("github");


### PR DESCRIPTION
This pull request should resolve #121.

Added a `redirectURL` configuration option and if this is missing will default to the `baseUrl`.