### PR TITLE
Add ability to mount the application and static assets at url fragment

### DIFF
--- a/lib/app.js
+++ b/lib/app.js
@@ -58,6 +58,12 @@ module.exports.initialize = function(config) {
       get appTitle() {
         return config.get("application").title;
       },
+      get mountpath() {
+        return config.get("application").mountpath;
+      },
+      get staticpath() {
+        return config.get("application").staticpath;
+      },
       get jingoVersion() {
         return program.version();
       },

--- a/lib/app.js
+++ b/lib/app.js
@@ -61,9 +61,6 @@ module.exports.initialize = function(config) {
       get mountpath() {
         return config.get("application").mountpath;
       },
-      get staticpath() {
-        return config.get("application").staticpath;
-      },
       get jingoVersion() {
         return program.version();
       },

--- a/lib/config.js
+++ b/lib/config.js
@@ -60,8 +60,7 @@ module.exports = (function() {
         pedanticMarkdown: true,
         gfmBreaks: true,
         staticWhitelist: "/\\.png$/i, /\\.jpg$/i, /\\.gif$/i",
-        mountpath: '',
-        staticpath: ''
+        mountpath: ''
       },
 
       authentication: {

--- a/lib/config.js
+++ b/lib/config.js
@@ -59,7 +59,9 @@ module.exports = (function() {
         loggingMode: 1,
         pedanticMarkdown: true,
         gfmBreaks: true,
-        staticWhitelist: "/\\.png$/i, /\\.jpg$/i, /\\.gif$/i"
+        staticWhitelist: "/\\.png$/i, /\\.jpg$/i, /\\.gif$/i",
+        mountpath: '',
+        staticpath: ''
       },
 
       authentication: {

--- a/lib/models.js
+++ b/lib/models.js
@@ -7,6 +7,15 @@ var Promise = require("bluebird"),
 
 var gitmech;
 
+var Configuration = function() {
+  Configurable.call(this);
+}
+
+Configuration.prototype = Object.create(Configurable.prototype);
+
+var configuration = new Configuration();
+var mountpath = configuration.getConfig().application.mountpath;
+
 function Page(name, revision) {
   name = name || "";
   this.setNames(name);
@@ -128,34 +137,34 @@ Page.prototype.urlFor = function(action) {
   switch(true) {
 
     case action == 'show':
-      return "/wiki/" + wname;
+      return mountpath + "/wiki/" + wname;
 
     case action == 'edit':
-      return "/pages/" + wname + "/edit";
+      return mountpath + "/pages/" + wname + "/edit";
 
     case action == 'edit error':
-      return "/pages/" + wname + "/edit?e=1";
+      return mountpath + "/pages/" + wname + "/edit?e=1";
 
     case action == 'edit put':
-      return "/pages/" + wname;
+      return mountpath + "/pages/" + wname;
 
     case action == 'revert':
-      return "/pages/" + wname + "/revert";
+      return mountpath + "/pages/" + wname + "/revert";
 
     case action == 'history':
-      return "/wiki/" + wname + "/history";
+      return mountpath + "/wiki/" + wname + "/history";
 
     case action == 'compare':
-      return "/wiki/" + wname + "/compare";
+      return mountpath + "/wiki/" + wname + "/compare";
 
     case action == 'new':
-      return "/pages/new/" + wname;
+      return mountpath + "/pages/new/" + wname;
 
     case action == 'new error':
-      return "/pages/new/" + wname + "?e=1";
+      return mountpath + "/pages/new/" + wname + "?e=1";
   }
 
-  return "/";
+  return mountpath + "/";
 };
 
 Page.prototype.urlForShow = function(action) {

--- a/lib/renderer.js
+++ b/lib/renderer.js
@@ -88,6 +88,8 @@ function evalTags(text) {
       name,
       pageName,
       re;
+  
+  var mountpath = configuration.getConfig().application.mountpath;
 
   for (var k in tagmap) {
     parts = tagmap[k].split("|");
@@ -97,7 +99,7 @@ function evalTags(text) {
     }
     pageName = encodeURIComponent(namer.wikify(pageName));
 
-    tagmap[k] = "<a class=\"internal\" href=\"/wiki/" + pageName + "\">" + name + "</a>";
+    tagmap[k] = "<a class=\"internal\" href=\"" + mountpath + "/wiki/" + pageName + "\">" + name + "</a>";
   }
 
   for (k in tagmap) {

--- a/public/css/style.css
+++ b/public/css/style.css
@@ -1,12 +1,12 @@
 body {
   padding-top: 40px; /* 40px to make the container go all the way to the bottom of the topbar */
   font-family: "Ubuntu";
-  background-image: url(/img/bodybg.png);
+  background-image: url(../img/bodybg.png);
 }
 
 a[href^="https://"],
 a[href^="http://"] {
-  background: url(/img/ext.png) center right no-repeat;
+  background: url(../img/ext.png) center right no-repeat;
   padding-right: 13px;
 }
 
@@ -146,7 +146,7 @@ h4 a, h4 a:hover {
 }
 
 hr {
-  background: transparent url(/img/hr-bg.png) repeat-x 0 0;
+  background: transparent url(../img/hr-bg.png) repeat-x 0 0;
   border: 0 none;
   color: #ccc;
   height: 4px;
@@ -596,7 +596,7 @@ li {
 }
 
 a.btn-auth {
-  background-image: url(/img/social-logins.png);
+  background-image: url(../img/social-logins.png);
   background-repeat: no-repeat;
   display: block;
   height: 5rem;

--- a/public/js/app.js
+++ b/public/js/app.js
@@ -5,9 +5,13 @@
 
   var $toolbar;
 
+  var mountpath;
+
   var Jingo = {
 
-    init: function() {
+    init: function(setMountpath) {
+      mountpath = setMountpath;
+
       var navh = $(".navbar").height(),
           $tools = $(".tools"),
           qs, hl = null;
@@ -128,7 +132,7 @@
           }
         });
 
-        $.getJSON("/misc/existence", {data: pages}, function(result) {
+        $.getJSON(mountpath + "/misc/existence", {data: pages}, function(result) {
           $.each(result.data, function(href, a) {
             $("#content a[href='\\/wiki\\/" + encodeURIComponent(a) + "']").addClass("absent");
           });
@@ -164,7 +168,7 @@
 
     preview: function() {
       $("#preview").modal({keyboard: true, show: true, backdrop: false});
-      $.post("/misc/preview", {data: $("#editor").val()}, function(data) {
+      $.post(mountpath + "/misc/preview", {data: $("#editor").val()}, function(data) {
         $("#preview .modal-body").html(data).get(0).scrollTop = 0;
       });
     },

--- a/public/js/app.js
+++ b/public/js/app.js
@@ -127,6 +127,7 @@
 
         $("#content a.internal").each(function(i, a) {
           href = $(a).attr("href");
+          href = href.slice(mountpath.length);
           if (match = /\/wiki\/(.+)/.exec(href)) {
             pages.push(decodeURIComponent(match[1]));
           }
@@ -134,7 +135,7 @@
 
         $.getJSON(mountpath + "/misc/existence", {data: pages}, function(result) {
           $.each(result.data, function(href, a) {
-            $("#content a[href='\\/wiki\\/" + encodeURIComponent(a) + "']").addClass("absent");
+            $("#content a[href='" + mountpath.split('/').join('\\/') + "\\/wiki\\/" + encodeURIComponent(a) + "']").addClass("absent");
           });
         });
       }

--- a/public/js/app.js
+++ b/public/js/app.js
@@ -96,7 +96,7 @@
         if ($hCol1.find(":checked").length < 2) {
           return false;
         }
-        window.location.href = "/wiki/" + $(this).data("pagename") + "/compare/" + $hCol1.find(":checked").map(function() { return $(this).val(); }).toArray().reverse().join("..");
+        window.location.href = mountpath + "/wiki/" + $(this).data("pagename") + "/compare/" + $hCol1.find(":checked").map(function() { return $(this).val(); }).toArray().reverse().join("..");
         return false;
       });
 
@@ -207,7 +207,7 @@
     markdownSyntax: function() {
       $("#syntax-reference").modal({keyboard: true, show: true, backdrop: false});
       if (!cheatsheetShown) {
-        $("#syntax-reference .modal-body").load("/misc/syntax-reference");
+        $("#syntax-reference .modal-body").load(mountpath + "/misc/syntax-reference");
         cheatsheetShown = true;
       }
     }

--- a/routes/auth.js
+++ b/routes/auth.js
@@ -8,24 +8,29 @@ var router = require("express").Router(),
 
 var auth = app.locals.config.get("authentication");
 var passport = app.locals.passport;
+var mountpath = app.locals.config.get("application").mountpath;
 
 router.get("/login", _getLogin);
 router.get("/logout", _getLogout);
-router.post("/login", passport.authenticate('local', { successRedirect: '/auth/done', failureRedirect: '/login', failureFlash: true }));
+router.post("/login", passport.authenticate('local', {
+    successRedirect: mountpath + '/auth/done',
+    failureRedirect: mountpath + '/login',
+    failureFlash: true 
+}));
 router.get("/auth/done", _getAuthDone);
 
 router.get("/auth/google", passport.authenticate('google', {
   scope: ['https://www.googleapis.com/auth/userinfo.email', 'https://www.googleapis.com/auth/userinfo.profile' ] }
 ));
 router.get("/oauth2callback", passport.authenticate('google', {
-  successRedirect: '/auth/done',
-  failureRedirect: '/login'
+  successRedirect: mountpath + '/auth/done',
+  failureRedirect: mountpath + '/login'
 }));
 
 router.get("/auth/github", passport.authenticate('github'));
 router.get("/auth/github/callback", passport.authenticate('github', {
-  successRedirect: '/auth/done',
-  failureRedirect: '/login'
+  successRedirect: mountpath + '/auth/done',
+  failureRedirect: mountpath + '/login'
 }));
 
 if (auth.google.enabled) {
@@ -144,13 +149,13 @@ passport.deserializeUser(function(user, done) {
 function _getLogout(req, res) {
   req.logout();
   req.session = null;
-  res.redirect('/');
+  res.redirect(mountpath + '/');
 }
 
 function _getAuthDone(req, res) {
 
   if (!res.locals.user) {
-    res.redirect("/");
+    res.redirect(mountpath + "/");
     return;
   }
 
@@ -164,7 +169,7 @@ function _getAuthDone(req, res) {
     res.statusCode = 403;
     res.end('<h1>Forbidden</h1>');
   } else {
-    var dst = req.session.destination || "/";
+    var dst = req.session.destination || mountpath + "/";
     delete req.session.destination;
     res.redirect(dst);
   }

--- a/routes/pages.js
+++ b/routes/pages.js
@@ -15,6 +15,7 @@ router.delete("/pages/:page", _deletePages);
 router.get("/pages/:page/revert/:version", _getRevert);
 
 var pagesConfig = app.locals.config.get("pages");
+var mountpath = app.locals.config.get("application").mountpath;
 
 function _deletePages(req, res) {
 
@@ -22,7 +23,7 @@ function _deletePages(req, res) {
 
   if (page.isIndex() || !page.exists()) {
     req.session.notice = "The page cannot be deleted.";
-    res.redirect("/");
+    res.redirect(mountpath + "/");
     return;
   }
 
@@ -41,7 +42,7 @@ function _deletePages(req, res) {
     }
 
     req.session.notice = "The page `" + page.wikiname + "` has been deleted.";
-    res.redirect("/");
+    res.redirect(mountpath + "/");
   });
 }
 
@@ -151,7 +152,7 @@ function _putPages(req, res) {
   // Highly unluckly (someone deleted the page we were editing)
   if (!page.exists()) {
     req.session.notice = "The page does not exist anymore.";
-    res.redirect("/");
+    res.redirect(mountpath + "/");
     return;
   }
 

--- a/routes/wiki.js
+++ b/routes/wiki.js
@@ -6,6 +6,8 @@ var router = require("express").Router(),
     app    = require("../lib/app").getInstance(),
     Promise = require("bluebird");
 
+var mountpath = app.locals.config.get("application").mountpath;
+
 models.use(Git);
 
 router.get("/", _getIndex);
@@ -227,7 +229,7 @@ function _getCompare(req, res) {
 }
 
 function _getIndex(req, res) {
-  res.redirect('/wiki/' + app.locals.config.get("pages").index);
+  res.redirect(mountpath + '/wiki/' + app.locals.config.get("pages").index);
 }
 
 module.exports = router;

--- a/views/create.jade
+++ b/views/create.jade
@@ -10,7 +10,7 @@ block content
     mixin errors()
     h1 Create a new page
 
-    form(action='/pages', method='post', class='edit')
+    form(action='#{mountpath}/pages', method='post', class='edit')
 
       input(type="hidden", name="pageName", value="#{coalesce(pageName, '')}")
 

--- a/views/layout.jade
+++ b/views/layout.jade
@@ -1,3 +1,5 @@
+include mixins/links
+
 doctype html
 html
   head
@@ -5,11 +7,11 @@ html
     meta(name="generator", content="jingo #{jingoVersion}")
     meta(name="viewport", content="width=device-width, initial-scale=1")
     title= title
-    link(rel="stylesheet", href="/vendor/bootstrap/css/bootstrap.min.css")
+    +cssAsset("/vendor/bootstrap/css/bootstrap.min.css")
     link(rel="stylesheet", href="//fonts.googleapis.com/css?family=Ubuntu|Ubuntu+Condensed")
-    link(rel="stylesheet", href="/css/style.css")
-    link(rel="stylesheet", href="/css/ionicons.min.css")
-    link(rel="stylesheet", href="/css/shCoreDefault.css")
+    +cssAsset("/css/style.css")
+    +cssAsset("/css/ionicons.min.css")
+    +cssAsset("/css/shCoreDefault.css")
     block styles
     if hasCustomStyle()
       style.
@@ -19,9 +21,9 @@ html
     .navbar.navbar-inverse.navbar-fixed-top
       .container-fluid
         .navbar-header
-          a(href="/").navbar-brand #{appTitle}
+          +relHref("/", appTitle).navbar-brand
           if canSearch()
-            form(action="/search").navbar-form.search.navbar-left
+            form(action="#{mountpath}/search").navbar-form.search.navbar-left
               .input-group.input-group-sm.search
                 input.form-control(type="text", value="#{term_ph}", data-i-search-input="true",name="term",placeholder="Search the wiki")
                 span.input-group-btn
@@ -29,13 +31,13 @@ html
           .navbar-right
             if isAnonymous()
               p.user You're not&nbsp;
-                a(id='login',href='/login?destination', title='Access login page') logged in
+                +relHref('/login?destination', 'logged in')#login(title='Access login page')
             else
               p.user
                 if user.email
                   img(src=gravatar().url("#{user.email}", {s:24}))
                 b &nbsp;#{user.displayName}&nbsp;
-                a.logout(href='/logout', title='Become anonymous')
+                +relHref('/logout')(title='Become anonymous')
                   i.icon.ion-power
 
     .tools
@@ -61,11 +63,11 @@ html
 
     script(src="http://ajax.googleapis.com/ajax/libs/jquery/1/jquery.min.js")
     script.
-      window.jQuery || document.write("<sc" + "ript src='/vendor/jquery.min.js'></scr" + "ipt>");
-    script(src="/vendor/bootstrap/js/bootstrap.min.js")
-    script(src="/js/app.js")
+      window.jQuery || document.write("<sc" + "ript src='#{staticpath}/vendor/jquery.min.js'></scr" + "ipt>");
+    +scriptAsset("/vendor/bootstrap/js/bootstrap.min.js")
+    +scriptAsset("/js/app.js")
     script.
-      Jingo.init();
+      Jingo.init("#{mountpath}");
     block scripts
     if hasCustomScript()
       script.

--- a/views/layout.jade
+++ b/views/layout.jade
@@ -63,7 +63,7 @@ html
 
     script(src="http://ajax.googleapis.com/ajax/libs/jquery/1/jquery.min.js")
     script.
-      window.jQuery || document.write("<sc" + "ript src='#{staticpath}/vendor/jquery.min.js'></scr" + "ipt>");
+      window.jQuery || document.write("<sc" + "ript src='#{mountpath}/vendor/jquery.min.js'></scr" + "ipt>");
     +asset("/vendor/bootstrap/js/bootstrap.min.js")
     +asset("/js/app.js")
     script.

--- a/views/layout.jade
+++ b/views/layout.jade
@@ -7,11 +7,11 @@ html
     meta(name="generator", content="jingo #{jingoVersion}")
     meta(name="viewport", content="width=device-width, initial-scale=1")
     title= title
-    +cssAsset("/vendor/bootstrap/css/bootstrap.min.css")
+    +asset("/vendor/bootstrap/css/bootstrap.min.css")
     link(rel="stylesheet", href="//fonts.googleapis.com/css?family=Ubuntu|Ubuntu+Condensed")
-    +cssAsset("/css/style.css")
-    +cssAsset("/css/ionicons.min.css")
-    +cssAsset("/css/shCoreDefault.css")
+    +asset("/css/style.css")
+    +asset("/css/ionicons.min.css")
+    +asset("/css/shCoreDefault.css")
     block styles
     if hasCustomStyle()
       style.
@@ -64,8 +64,8 @@ html
     script(src="http://ajax.googleapis.com/ajax/libs/jquery/1/jquery.min.js")
     script.
       window.jQuery || document.write("<sc" + "ript src='#{staticpath}/vendor/jquery.min.js'></scr" + "ipt>");
-    +scriptAsset("/vendor/bootstrap/js/bootstrap.min.js")
-    +scriptAsset("/js/app.js")
+    +asset("/vendor/bootstrap/js/bootstrap.min.js")
+    +asset("/js/app.js")
     script.
       Jingo.init("#{mountpath}");
     block scripts

--- a/views/login.jade
+++ b/views/login.jade
@@ -1,6 +1,7 @@
 extends layout
 
 include mixins/form
+include mixins/links
 
 block content
 
@@ -10,15 +11,15 @@ block content
 
     if (auth.google.enabled)
       p
-        a.btn-auth.btn-auth-google(href="/auth/google") Google login
+        +relHref('/auth/google', 'Google login').btn-auth.btn-auth-google
 
     if (auth.github.enabled)
       p
-        a.btn-auth.btn-auth-github(href="/auth/github") Github login
+        +relHref('/auth/github', 'Github login').btn-auth.btn-auth-github
 
     if (auth.google.enabled || auth.github.enabled)
       p
-        a(href="/") Cancel
+        +relHref("/", 'Cancel')
 
     if (auth.alone.enabled || auth.local.enabled)
 
@@ -27,7 +28,7 @@ block content
 
       mixin errors()
 
-      form.form-horizontal(action='/login', method='post')
+      form.form-horizontal(action='#{mountpath}/login', method='post')
 
         .form-group
           label.col-sm-2.control-label Username
@@ -43,4 +44,4 @@ block content
           .col-sm-offset-2.col-sm-3
             button.btn-primary.btn(type="submit") Login
             |&nbsp;or&nbsp;
-            a(href="/") cancel
+            +relHref("/", 'Cancel')

--- a/views/mixins/form.jade
+++ b/views/mixins/form.jade
@@ -55,25 +55,25 @@ mixin errors(err)
 
 mixin featuresStylesheets()
   if hasFeature('markitup')
-    +cssAsset("/vendor/widearea/widearea.min.css")(type="text/css")
-    +cssAsset("/vendor/markitup/skins/simple/style.css")(type="text/css")
-    +cssAsset("/vendor/markitup/sets/markdown/style.css")(type="text/css")
+    +asset("/vendor/widearea/widearea.min.css")(type="text/css")
+    +asset("/vendor/markitup/skins/simple/style.css")(type="text/css")
+    +asset("/vendor/markitup/sets/markdown/style.css")(type="text/css")
   if hasFeature('codemirror')
-    +cssAsset("/css/codemirror-ext.css")(type="text/css")
-    +cssAsset("/vendor/codemirror/codemirror.css")(type="text/css")
-    +cssAsset("/vendor/codemirror/fullscreen.css")(type="text/css")
+    +asset("/css/codemirror-ext.css")(type="text/css")
+    +asset("/vendor/codemirror/codemirror.css")(type="text/css")
+    +asset("/vendor/codemirror/fullscreen.css")(type="text/css")
 
 mixin featuresJavaScripts()
   if hasFeature('markitup')
-    +scriptAsset("/vendor/jquery-migrate-1.1.0.min.js")
-    +scriptAsset("/vendor/markitup/jquery.markitup.js")
-    +scriptAsset("/vendor/markitup/sets/markdown/set.js")
-    +scriptAsset("/vendor/widearea/widearea.min.js")
+    +asset("/vendor/jquery-migrate-1.1.0.min.js")
+    +asset("/vendor/markitup/jquery.markitup.js")
+    +asset("/vendor/markitup/sets/markdown/set.js")
+    +asset("/vendor/widearea/widearea.min.js")
     script.
      $('#editor').markItUp(markdownSettings);
      wideArea();
   if hasFeature('codemirror')
-    +scriptAsset("/vendor/codemirror/codemirror.min.js")
+    +asset("/vendor/codemirror/codemirror.min.js")
     script.
       Jingo.cmInstance = CodeMirror.fromTextArea(document.getElementById("editor"), {
         lineNumbers: true,

--- a/views/mixins/form.jade
+++ b/views/mixins/form.jade
@@ -1,9 +1,11 @@
+include links
+
 mixin tools(action, pageName)
   if action == 'edit'
     ul
       if pageName != 'home'
         li
-          form(action="/pages/#{pageName}", method="post", style="display:inline")
+          form(action="#{mountpath}/pages/#{pageName}", method="post", style="display:inline")
             input(type="hidden", name="_method", value="delete")
             input(type="submit", value="Delete this page").confirm-delete-page.btn.btn-default
 
@@ -11,36 +13,36 @@ mixin tools(action, pageName)
     ul
       if !isAnonymous()
         li
-          a(href="/pages/new", title="Create new page").btn.btn-sm.btn-default
+          +relHref("/pages/new")(title="Create new page").btn.btn-sm.btn-default
             i.icon.ion-plus-round
       if !isAnonymous() && canEdit
         li
-          a(href="/pages/#{pageName}/edit", title="Edit this page").btn.btn-sm.btn-default
+          +relHref("/pages/" + pageName + "/edit")(title="Edit this page").btn.btn-sm.btn-default
             i.icon.ion-compose
 
       li
-        a(href="/wiki/#{pageName}/history", title="Page history").btn.btn-sm.btn-default
+        +relHref("/wiki/" + pageName + "/history")(title="Page history").btn.btn-sm.btn-default
           i.icon.ion-clock
       li
-        a(href="/wiki", title="All pages").btn.btn-sm.btn-default
+        +relHref("/wiki")(title="All pages").btn.btn-sm.btn-default
           i.icon.ion-grid
 
       if canSearch()
         li
-          a(href="/search", title="Search through the pages").btn.btn-sm.btn-default
+          +relHref("/search")(title="Search through the pages").btn.btn-sm.btn-default
             i.icon.ion-search
 
   if action == 'history'
     ul
       li
-        a(href="/wiki", title="All pages").btn.btn-sm.btn-default
+        +relHref("/wiki")(title="All pages").btn.btn-sm.btn-default
           i.icon.ion-grid
 
 mixin saveAndCancel(saveText)
   .well
     input(type='submit',value=saveText || 'Save').btn.btn-primary
     |&nbsp;
-    a(href="/").btn Cancel
+    +relHref("/", "Cancel").btn
 
 mixin errors(err)
   -var errors = locals.errors;
@@ -53,25 +55,25 @@ mixin errors(err)
 
 mixin featuresStylesheets()
   if hasFeature('markitup')
-    link(rel="stylesheet", type="text/css", href="/vendor/widearea/widearea.min.css")
-    link(rel="stylesheet", type="text/css", href="/vendor/markitup/skins/simple/style.css")
-    link(rel="stylesheet", type="text/css", href="/vendor/markitup/sets/markdown/style.css")
+    +cssAsset("/vendor/widearea/widearea.min.css")(type="text/css")
+    +cssAsset("/vendor/markitup/skins/simple/style.css")(type="text/css")
+    +cssAsset("/vendor/markitup/sets/markdown/style.css")(type="text/css")
   if hasFeature('codemirror')
-    link(rel="stylesheet", type="text/css", href="/css/codemirror-ext.css")
-    link(rel="stylesheet", type="text/css", href="/vendor/codemirror/codemirror.css")
-    link(rel="stylesheet", type="text/css", href="/vendor/codemirror/fullscreen.css")
+    +cssAsset("/css/codemirror-ext.css")(type="text/css")
+    +cssAsset("/vendor/codemirror/codemirror.css")(type="text/css")
+    +cssAsset("/vendor/codemirror/fullscreen.css")(type="text/css")
 
 mixin featuresJavaScripts()
   if hasFeature('markitup')
-    script(src="/vendor/jquery-migrate-1.1.0.min.js")
-    script(src="/vendor/markitup/jquery.markitup.js")
-    script(src="/vendor/markitup/sets/markdown/set.js")
-    script(src="/vendor/widearea/widearea.min.js")
+    +scriptAsset("/vendor/jquery-migrate-1.1.0.min.js")
+    +scriptAsset("/vendor/markitup/jquery.markitup.js")
+    +scriptAsset("/vendor/markitup/sets/markdown/set.js")
+    +scriptAsset("/vendor/widearea/widearea.min.js")
     script.
      $('#editor').markItUp(markdownSettings);
      wideArea();
   if hasFeature('codemirror')
-    script(src="/vendor/codemirror/codemirror.min.js")
+    +scriptAsset("/vendor/codemirror/codemirror.min.js")
     script.
       Jingo.cmInstance = CodeMirror.fromTextArea(document.getElementById("editor"), {
         lineNumbers: true,

--- a/views/mixins/links.jade
+++ b/views/mixins/links.jade
@@ -2,8 +2,12 @@ mixin relHref(url, name)
   a(href="#{mountpath}" + url)&attributes(attributes)= name
     block
 
-mixin cssAsset(url)
-  link(rel="stylesheet", href="#{staticpath}" + url)
-
-mixin scriptAsset(url)
-  script(src="#{staticpath}" + url)
+mixin asset(url)
+  -
+    var link = staticpath + url
+    var match = /^.*?\.([a-zA-Z]+)$/.exec(url)
+    var ext = match.length > 1 ? match[1] : ''
+  if ext === 'css'
+    link(rel="stylesheet", href=link)
+  else if ext === 'js'
+    script(src=link)

--- a/views/mixins/links.jade
+++ b/views/mixins/links.jade
@@ -4,7 +4,7 @@ mixin relHref(url, name)
 
 mixin asset(url)
   -
-    var link = staticpath + url
+    var link = mountpath + url
     var match = /^.*?\.([a-zA-Z]+)$/.exec(url)
     var ext = match.length > 1 ? match[1] : ''
   if ext === 'css'

--- a/views/mixins/links.jade
+++ b/views/mixins/links.jade
@@ -1,0 +1,9 @@
+mixin relHref(url, name)
+  a(href="#{mountpath}" + url)&attributes(attributes)= name
+    block
+
+mixin cssAsset(url)
+  link(rel="stylesheet", href="#{staticpath}" + url)
+
+mixin scriptAsset(url)
+  script(src="#{staticpath}" + url)

--- a/views/search.jade
+++ b/views/search.jade
@@ -1,6 +1,7 @@
 extends layout
 
 include mixins/form
+include mixins/links
 
 block content
 
@@ -9,7 +10,7 @@ block content
     mixin warning()
 
     if canSearch()
-      form(action="/search").search-form
+      form(action="#{mountpath}/search").search-form
         .input-group.input-group-sm
           input.form-control(type="text", value="#{term_ph}", data-i-search-input="true",name="term",placeholder="Search the wiki")
           span.input-group-btn
@@ -22,6 +23,6 @@ block content
     dl.search-results
       each match in matches
         dt
-          a(href="/wiki/#{match.pageName}?hl=#{encodeURIComponent(term)}") #{match.pageName}
+          +relHref("/wiki/" + match.pageName + "?hl=" + encodeURIComponent(term), match.pageName)
           span.nl #{match.line}
         dd #{match.text}

--- a/views/welcome.jade
+++ b/views/welcome.jade
@@ -5,5 +5,5 @@ block content
   #content
     .jumbotron
       h1 Welcome to the wiki
-      p This page doesn't (yet) exist. You should first <a href="/login">login</a> and then you'll be redirected to the editor so that you can create the front page.
-      p <a class="btn btn-primary btn-large" href="/login">Login</a> and start adding content!
+      p This page doesn't (yet) exist. You should first <a href="#{mountpath}/login">login</a> and then you'll be redirected to the editor so that you can create the front page.
+      p <a class="btn btn-primary btn-large" href="#{mountpath}/login">Login</a> and start adding content!


### PR DESCRIPTION
  * Added `mountpath` and `staticpath` to configuration options
  * Added `cssAsset`, `scriptAsset`, and `relHref` mixins to jade templates
    * `cssAsset` and `scriptAsset` prepend with the `staticpath`
    * `relHref` prepends `mountpath` to the uri and allows for `block` and attributes such as `class`
  * Modified the internal js to render links relative to the `mountpath`
  * Modified `style.css` so that the images load relative to the current directory

PR meant to add to issue #124 