### PR TITLE
Fix TOC anchor tags bug

### DIFF
--- a/lib/directives.js
+++ b/lib/directives.js
@@ -1,7 +1,10 @@
 var directives = {
   TOC: function(text) {
     var toc = require('markdown-toc');
-    return toc(text).content;
+    text = text.split('\n').slice(1).join('\n');
+    return toc(text, {slugify: function(str) {
+      return str.toLowerCase().replace(/[^\w]+/g, '-');
+    }}).content;
   }
 };
 


### PR DESCRIPTION
There was a problem with anchor tags and the table of contents generated by `markdown-toc` for non-alphanumeric characters. I fixed this by changing the `slugify` option to that used by **Marked**.