### PR TITLE
removed the protocol

### DIFF
--- a/views/layout.jade
+++ b/views/layout.jade
@@ -59,7 +59,7 @@ html
           .col-md-8.with-footer
             .content !{_footer}
 
-    script(src="http://ajax.googleapis.com/ajax/libs/jquery/1/jquery.min.js")
+    script(src="//ajax.googleapis.com/ajax/libs/jquery/1/jquery.min.js")
     script.
       window.jQuery || document.write("<sc" + "ript src='/vendor/jquery.min.js'></scr" + "ipt>");
     script(src="/vendor/bootstrap/js/bootstrap.min.js")


### PR DESCRIPTION
Firefox was moaning about the insecure source while using it as https enabled and anyways the browser will use the protocol that the page was loaded with so no need to have the protocol specified.