### PR TITLE
Add cloudron oauth support

### DIFF
--- a/lib/config.js
+++ b/lib/config.js
@@ -76,6 +76,9 @@ module.exports = (function () {
           clientSecret: "replace me with the real value",
           redirectURL: ""
         },
+        cloudron: {
+          enabled: false
+        },
         // @deprecated, use local with just an user
         alone: {
           enabled: false,
@@ -155,6 +158,7 @@ module.exports = (function () {
 
       if (!config.authentication.google.enabled &&
         !config.authentication.github.enabled &&
+        !config.authentication.cloudron.enabled &&
         !config.authentication.alone.enabled &&
         !config.authentication.local.enabled
       ) {

--- a/package.json
+++ b/package.json
@@ -44,6 +44,7 @@
     "morgan": "^1.5.0",
     "node-syntaxhighlighter": "*",
     "passport": "^0.2.0",
+    "passport-cloudron": "^0.3.2",
     "passport-github": "^0.1.5",
     "passport-google-oauth": "^0.1.5",
     "passport-local": "^1.0.0",

--- a/routes/auth.js
+++ b/routes/auth.js
@@ -4,6 +4,7 @@ var router = require("express").Router(),
   passportLocal = require("passport-local"),
   passportGoogle = require("passport-google-oauth"),
   passportGithub = require("passport-github").Strategy,
+  passportCloudron = require("passport-cloudron"),
   tools = require("../lib/tools");
 
 var auth = app.locals.config.get("authentication");
@@ -29,6 +30,12 @@ router.get("/oauth2callback", passport.authenticate("google", {
 
 router.get("/auth/github", passport.authenticate("github"));
 router.get("/auth/github/callback", passport.authenticate("github", {
+  successRedirect: proxyPath + "/auth/done",
+  failureRedirect: proxyPath + "/login"
+}));
+
+router.get("/auth/cloudron", passport.authenticate("cloudron"));
+router.get("/auth/cloudron/callback", passport.authenticate("cloudron", {
   successRedirect: proxyPath + "/auth/done",
   failureRedirect: proxyPath + "/login"
 }));
@@ -62,6 +69,19 @@ if (auth.github.enabled) {
   },
     function (accessToken, refreshToken, profile, done) {
       usedAuthentication("github");
+      done(null, profile);
+    }
+  ));
+}
+
+if (auth.cloudron.enabled) {
+  var redirectURL = process.env.APP_ORIGIN + "/auth/cloudron/callback";
+
+  passport.use(new passportCloudron({
+    callbackURL: redirectURL
+  },
+    function (accessToken, refreshToken, profile, done) {
+      usedAuthentication("cloudron");
       done(null, profile);
     }
   ));

--- a/views/layout.jade
+++ b/views/layout.jade
@@ -50,17 +50,22 @@ include mixins/links
           if hasSidebar()
             .col-md-2.with-sidebar
               .content !{_sidebar}
-          else
-            .col-md-2
 
-          #main.hide-tools.col-md-8
-            block content
+            #main.hide-tools.col-md-10
+              block content
+          else
+            #main.hide-tools.col-md-12
+              block content
 
         if hasFooter()
           .row
-            .col-md-2
-            .col-md-8.with-footer
-              .content !{_footer}
+            if hasSidebar()
+              .col-md-2
+              .col-md-10.with-footer
+                .content !{_footer}
+            else
+              .col-md-12.with-footer
+                .content !{_footer}
 
       script(src="//ajax.googleapis.com/ajax/libs/jquery/1/jquery.min.js")
       script.

--- a/views/login.jade
+++ b/views/login.jade
@@ -17,6 +17,10 @@ block content
       p
         +anchor('/auth/github', 'Github login').btn-auth.btn-auth-github
 
+    if (auth.cloudron.enabled)
+      p
+        a.btn.btn-primary(href="/auth/cloudron") Cloudron Login
+
     if (auth.google.enabled || auth.github.enabled)
       p
         +anchor("/", 'Cancel')


### PR DESCRIPTION
This will probably go down the way of https://github.com/claudioc/jingo/pull/26 but I thought I will put this here anyway :-)

I made a Cloudron app for Jingo (https://github.com/cloudron-io/jingo-app). As part of the app, I added Cloudron OAuth2 support to Jingo. The patch itself is very straightforward. I haven't published the app to our store yet, so it's a little hard to see how the Jingo app looks like (since I am waiting for a logo - opened an issue for that).