### PR TITLE
jingo needs to be installed globally to use it as a command

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ For code syntax highlighting, Jingo uses the `node-syntaxhighlighter` module. Fo
 Installation
 ------------
 
-`npm install jingo` or download/clone the whole thing and run `npm install`.
+`npm install -g jingo` or download/clone the whole thing and run `npm install`.
 
 Note: if you already have Jingo installed, please also run `npm prune` (some modules can be stale and need to be removed).
 


### PR DESCRIPTION
The rest of the README assumes that "jingo" command is available after installation, but that will only be the case if it is installed globally, via npm so the "-f" flag was missing. Tiny detail, but may save somebody not too familiar with Node, some headache.