### PR TITLE
Update bracket tag regexp

### DIFF
--- a/lib/renderer.js
+++ b/lib/renderer.js
@@ -62,7 +62,7 @@ function extractTags(text) {
 
   tagmap = {};
 
-  var matches = text.match(/(.?)\[\[(.+?)\]\]([^\[]?)/g),
+  var matches = text.match(/(.?)\[\[(.+?)\]\]/g),
     tag,
     id;
 

--- a/test/spec/rendererSpec.js
+++ b/test/spec/rendererSpec.js
@@ -38,6 +38,11 @@ describe ("Renderer", function() {
     expect(Renderer.render(text)).to.be.equal("<p>a <a class=\"internal\" href=\"/wiki/Foo-%2B-Bar\">Foo / Bar</a> b</p>\n");
   });
 
+  it ("should render bracket tags8", function() {
+    var text = "[[Foo]], [[Bar]]";
+    expect(Renderer.render(text)).to.be.equal("<p><a class=\"internal\" href=\"/wiki/Foo\">Foo</a>, <a class=\"internal\" href=\"/wiki/Bar\">Bar</a></p>\n");
+  });
+
   it ("should replace {{TOC}} with the table of contents", function() {
     var text = "{{TOC}}\n\n # Heading 1 \n\n This is some text";
     expect(Renderer.render(text)).to.be.equal("<ul>\n<li><p><a href=\"#heading-1\">Heading 1</a></p>\n<h1 id=\"heading-1\">Heading 1</h1>\n<p>This is some text</p>\n</li>\n</ul>\n");


### PR DESCRIPTION
If I type out a comma-separated list of bracket tags -- `[[a]], [[b], [[c]` -- Jingo eats the commas between each link. Not really sure what the last match group of the regexp below is supposed to do, but removing it fixed my issue without breaking the other tests. 