### PR TITLE
Add support for github enterprise

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,7 +130,7 @@ For GitHub, follow these instructions (you need to be logged in in GitHub):
 * Press the `Register application` button
 * In the following page, on the top right corner, take note of the values for `Client ID` and `Client Secret`
 * Now you need to copy the `Client ID` and `Client secret` in your jingo config file in the proper places
-* Change `authorizationURL` `tokenURL` `userProfileURL` in the config file to your own url if you want to use github enterprise, or leave them empty
+* Change `authorizationURL` `tokenURL` `userProfileURL` in the config file to your own url if you want to use github enterprise, or leave them empty for the default values: `authorizationURL: https://github.com/login/oauth/authorize` `authorizationURL: https://github.com/login/oauth/access_token` `userProfileURL: https://api.github.com/user`
 
 The _local_ method uses an array of `username`, `passwordHash` and optionally an `email`. The password is hashed using a _non salted_ SHA-1 algorithm, which makes this method not the safest in the world but at least you don't have a clear text password in the config file. To generate the hash, use the `--hash-string` program option: once you get the hash, copy it in the config file.
 

--- a/README.md
+++ b/README.md
@@ -130,6 +130,7 @@ For GitHub, follow these instructions (you need to be logged in in GitHub):
 * Press the `Register application` button
 * In the following page, on the top right corner, take note of the values for `Client ID` and `Client Secret`
 * Now you need to copy the `Client ID` and `Client secret` in your jingo config file in the proper places
+* Change `authorizationURL` `tokenURL` `userProfileURL` in the config file to your own url if you want to use github enterprise, or leave them empty
 
 The _local_ method uses an array of `username`, `passwordHash` and optionally an `email`. The password is hashed using a _non salted_ SHA-1 algorithm, which makes this method not the safest in the world but at least you don't have a clear text password in the config file. To generate the hash, use the `--hash-string` program option: once you get the hash, copy it in the config file.
 

--- a/lib/config.js
+++ b/lib/config.js
@@ -74,6 +74,9 @@ module.exports = (function () {
           enabled: false,
           clientId: "replace me with the real value",
           clientSecret: "replace me with the real value",
+          authorizationURL: "leave me empty to https://github.com/login/oauth/authorize",
+          tokenURL: "leave me empty to https://github.com/login/oauth/access_token",
+          userProfileURL: "leave me empty to https://api.github.com/user",
           redirectURL: ""
         },
         // @deprecated, use local with just an user

--- a/lib/config.js
+++ b/lib/config.js
@@ -74,9 +74,9 @@ module.exports = (function () {
           enabled: false,
           clientId: "replace me with the real value",
           clientSecret: "replace me with the real value",
-          authorizationURL: "leave me empty to https://github.com/login/oauth/authorize",
-          tokenURL: "leave me empty to https://github.com/login/oauth/access_token",
-          userProfileURL: "leave me empty to https://api.github.com/user",
+          authorizationURL: "",
+          tokenURL: "",
+          userProfileURL: "",
           redirectURL: ""
         },
         // @deprecated, use local with just an user

--- a/routes/auth.js
+++ b/routes/auth.js
@@ -58,6 +58,9 @@ if (auth.github.enabled) {
   passport.use(new passportGithub({
     clientID: auth.github.clientId,
     clientSecret: auth.github.clientSecret,
+    authorizationURL: auth.github.authorizationURL,
+    tokenURL: auth.github.tokenURL,
+    userProfileURL: auth.github.userProfileURL,
     callbackURL: redirectURL
   },
     function (accessToken, refreshToken, profile, done) {


### PR DESCRIPTION
see also: https://github.com/jaredhanson/passport-github/blob/master/lib/strategy.js#L53

passport-github allows passing these options to support a private github enterprise instance.
