### PR TITLE
Introduce OpenSteetMap via OAuth2

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,9 +107,9 @@ If you want your wiki server to only listen to your `localhost`, set the configu
 Authentication and Authorization
 --------------------------------
 
-You can enable the following strategies: _Google logins (OAuth2)_, _GitHub logins (OAuth2)_ or a simple, locally verified username/password credentials match (called "local").
+You can enable the following strategies: _Google logins (OAuth2)_, _GitHub logins (OAuth2)_, _OpenStreetMap logins (OAuth2)_ or a simple, locally verified username/password credentials match (called "local").
 
-The _Google Login_ and the _GitHub login_ uses OAuth 2 and that means that on a fresh installation you need to get a `client id` and a `client secret` from Google or GitHub and put those informations in the configuration file.
+The _Google Login_ and the _GitHub login_ (as the _OpenStreetMap login_) uses OAuth 2 and that means that on a fresh installation you need to get a `client id` and a `client secret` from Google or GitHub and put those informations in the configuration file.
 
 For Google, follow these instructions (you need to be logged in in Google):
 
@@ -128,6 +128,19 @@ For GitHub, follow these instructions (you need to be logged in in GitHub):
 * Enter your installation URL (localhost is OK, for example "http://localhost:6767/")
 * Enter <your installation URL>/auth/github/callback as the `Authorization callback URL`
 * Press the `Register application` button
+* In the following page, on the top right corner, take note of the values for `Client ID` and `Client Secret`
+* Now you need to copy the `Client ID` and `Client secret` in your jingo config file in the proper places
+
+For OpenStreetMap, follow these instructions (you need to be logged in in OpenSteetMap):
+
+* Go to the Settings of your User Account
+* Open OAuth Settings
+* Scoll until the end of the screen and open Register Application
+* Enter whatever `Application name` you want
+* Enter your installation URL (localhost is OK, for example "http://localhost:6767/")
+* Enter <your installation URL>/auth/opensteetmap/callback as the `Authorization callback URL`
+* You need only to allow the reading of user data
+* Press the `Register` button
 * In the following page, on the top right corner, take note of the values for `Client ID` and `Client Secret`
 * Now you need to copy the `Client ID` and `Client secret` in your jingo config file in the proper places
 
@@ -274,7 +287,20 @@ Configuration options reference
 
   Values required for GitHub OAuth2 authentication. Refer to a previous section of this document on how to set them up.
 
-#### authentication.google.redirectUrl (string: /auth/github/callback)
+#### authentication.github.redirectUrl (string: /auth/github/callback)
+
+  Specifies a custom redirect URL for OAuth2 authentication instead of the default
+
+#### authentication.openstreetmap.enabled (boolean: false)
+
+  Enable or disable authentication via OpenSteetMap logins
+
+#### authentication.openstreetmap.clientId
+#### authentication.openstreetmap.clientSecret
+
+  Values required for OpenSteetMap OAuth2 authentication. Refer to a previous section of this document on how to set them up.
+
+#### authentication.openstreetmap.redirectUrl (string: /auth/openstreetmap/callback)
 
   Specifies a custom redirect URL for OAuth2 authentication instead of the default
 

--- a/README.md
+++ b/README.md
@@ -143,6 +143,7 @@ For OpenStreetMap, follow these instructions (you need to be logged in in OpenSt
 * Press the `Register` button
 * In the following page, on the top right corner, take note of the values for `Client ID` and `Client Secret`
 * Now you need to copy the `Client ID` and `Client secret` in your jingo config file in the proper places
+* If you are using OpenSteetMap OAuth2 please disable _authorization.emptyEmailMatches_ as OpenStreetMap is NOT publishing User EMail adresses.
 
 The _local_ method uses an array of `username`, `passwordHash` and optionally an `email`. The password is hashed using a _non salted_ SHA-1 algorithm, which makes this method not the safest in the world but at least you don't have a clear text password in the config file. To generate the hash, use the `--hash-string` program option: once you get the hash, copy it in the config file.
 

--- a/lib/app.js
+++ b/lib/app.js
@@ -19,7 +19,7 @@ var express      = require("express"),
   cookieParser   = require("cookie-parser"),
   logger         = require("morgan"),
   program        = require("commander"),
-  cookieSession  = require("cookie-session"),
+  //cookieSession  = require("cookie-session"),
   gravatar       = require("gravatar"),
   passport       = require("passport"),
   methodOverride = require("method-override"),
@@ -122,11 +122,11 @@ module.exports.initialize = function (config) {
 
   app.use(express.static(path.join(__dirname + "/../", "public")));
   app.use(cookieParser());
-  app.use(cookieSession({
+  /*app.use(cookieSession({
     name: "JingoSession",
     keys: ["jingo"],
     cookie: { maxAge: 30 * 24 * 60 * 60 * 1000 }
-  }));
+  }));*/
   app.use(session({ name: "jingosid",
                     secret: config.get("application").secret,
                     cookie: { httpOnly: true },

--- a/lib/config.js
+++ b/lib/config.js
@@ -76,6 +76,13 @@ module.exports = (function () {
           clientSecret: "replace me with the real value",
           redirectURL: ""
         },
+        openstreetmap: {
+          enabled: false,
+          clientId: "replace me with the real value",
+          clientSecret: "replace me with the real value",
+          redirectURL: ""
+        },
+        
         // @deprecated, use local with just an user
         alone: {
           enabled: false,
@@ -155,6 +162,7 @@ module.exports = (function () {
 
       if (!config.authentication.google.enabled &&
         !config.authentication.github.enabled &&
+        !config.authentication.openstreetmap.enabled &&
         !config.authentication.alone.enabled &&
         !config.authentication.local.enabled
       ) {

--- a/lib/config.js
+++ b/lib/config.js
@@ -60,7 +60,8 @@ module.exports = (function () {
         pedanticMarkdown: true,
         gfmBreaks: true,
         staticWhitelist: "/\\.png$/i, /\\.jpg$/i, /\\.gif$/i",
-        proxyPath: ""
+        proxyPath: "",
+        pgConnection: ""
       },
 
       authentication: {

--- a/lib/tools.js
+++ b/lib/tools.js
@@ -1,8 +1,24 @@
 var cryptoz = require("crypto");
 
+var pg = require('pg');
+
+
 var tools = {
 
+  isValidUser: function (user,connectStr,callback) {
+    pg.connect(connectStr, function(err, client, pgdone) {
+      if (err) return callback(err);
+      client.query("select count(*) as number from usert where data->>'OSMUser' = $1 and data->>'access' = 'full' ",[user.displayName],function(err,result){
+        if (err) return callback(err);
+        return callback(null,(result.rows[0].number == '1'));
+      });
+    });
+  },
+
   isAuthorized: function (email, pattern, emptyEmailMatches) {
+
+    // specific OSMBC Code to check, wether the user is known in OSMBC
+
 
     // Special case where the email is not returned by the backend authorization system
     if (email == "jingouser") {

--- a/package.json
+++ b/package.json
@@ -47,6 +47,7 @@
     "passport-github": "^0.1.5",
     "passport-google-oauth": "^0.1.5",
     "passport-local": "^1.0.0",
+    "pg": "^6.1.0",
     "semver": "^2.3.2",
     "serve-favicon": "^2.1.7",
     "transliteration": "^0.1.1"

--- a/views/login.jade
+++ b/views/login.jade
@@ -17,7 +17,11 @@ block content
       p
         +anchor('/auth/github', 'Github login').btn-auth.btn-auth-github
 
-    if (auth.google.enabled || auth.github.enabled)
+    if (auth.openstreetmap.enabled)
+      p
+        +anchor('/auth/openstreetmap', 'OpenSteetMap login').btn-default 
+
+    if (auth.google.enabled || auth.github.enabled || auth.openstreetmap.enabled)
       p
         +anchor("/", 'Cancel')
 


### PR DESCRIPTION
This Pull Request introduces OpenStreetMap Authorization via OAuth2.

OpenStreetMap is not supporting any email fields, so you have to ignore email to use, this is documented in the Readme.

Other parts of this pull request:

a) disabled CookieSession

cookie-session and express-session are doing similar things (http://stackoverflow.com/questions/15744897/what-is-the-difference-between-session-and-cookiesession-middleware-in-conne) and i had trouble using the OpenStreetMap OAuth mechanism with CookieSession enabled, so i just have commented it out.

b) Introduced OpenStreetMap related staff, similar to Google or GitHub OAuth.

All test are still running.
