### PR TITLE
Add support for specifying ldap auth option, searchAttributes, from config.yaml

### DIFF
--- a/routes/auth.js
+++ b/routes/auth.js
@@ -89,7 +89,8 @@ if (auth.ldap.enabled) {
         bindDn: auth.ldap.bindDn,
         bindCredentials: auth.ldap.bindCredentials,
         searchBase: auth.ldap.searchBase,
-        searchFilter: auth.ldap.searchFilter
+        searchFilter: auth.ldap.searchFilter,
+        searchAttributes: auth.ldap.searchAttributes
       }
   },
     function (profile, done) {


### PR DESCRIPTION
Fixes issue #178 by allowing the "searchAttributes" option of the passport ldap module to be specified from the config.yaml file.

The following example from config.yaml will limit the returned search attributes to just displayName and mail

``` yaml
    searchAttributes:
      - displayName
      - mail
```
