### PR TITLE
Support authentication through Github Enterprise

### DIFF
--- a/routes/auth.js
+++ b/routes/auth.js
@@ -75,7 +75,10 @@ if (auth.github.enabled) {
   passport.use(new passportGithub({ // eslint-disable-line new-cap
     clientID: auth.github.clientId,
     clientSecret: auth.github.clientSecret,
-    callbackURL: redirectURL
+    callbackURL: redirectURL,
+    authorizationURL: auth.github.authorizationURL,
+    tokenURL: auth.github.tokenURL,
+    userProfileURL: auth.github.userProfileURL
   },
     function (accessToken, refreshToken, profile, done) {
       usedAuthentication('github')


### PR DESCRIPTION
config.yml is consulted for various Github URLs so that
Jingo can connect to Github instances hosted at arbitrary locations.

E.g. to login using https://mygithub.com one can add the following
configuration (tested with Github Enterprise 2.6):

  github:
    enabled: true
    redirectURL: ''
    clientId: <clientid>
    clientSecret: <clientsecret>
    authorizationURL: https://mygithub.com/login/oauth/authorize
    tokenURL: https://mygithub.com/login/oauth/access_token
    userProfileURL:  https://mygithub.com/api/v3/user