### PR TITLE
fixed renderer for bold and italic bracket tags

### DIFF
--- a/lib/renderer.js
+++ b/lib/renderer.js
@@ -60,7 +60,7 @@ var tagmap = {}
 function extractTags (text) {
   tagmap = {}
 
-  var matches = text.match(/(.?)\[\[(.+?)\]\]/g)
+  var matches = text.match(/\[\[(.+?)\]\]/g)
   var tag
   var id
 

--- a/test/spec/rendererSpec.js
+++ b/test/spec/rendererSpec.js
@@ -44,6 +44,21 @@ describe('Renderer', function () {
     expect(Renderer.render(text)).to.be.equal('<p><a class="internal" href="/wiki/Foo">Foo</a>, <a class="internal" href="/wiki/Bar">Bar</a></p>\n')
   })
 
+  it('should render bold bracket tags', function () {
+    var text = 'foo **[[Bar]]** buzz'
+    expect(Renderer.render(text)).to.be.equal('<p>foo <strong><a class="internal" href="/wiki/Bar">Bar</a></strong> buzz</p>\n')
+  })
+
+  it('should render italic bracket tags', function () {
+    var text = 'foo *[[Bar]]* buzz'
+    expect(Renderer.render(text)).to.be.equal('<p>foo <em><a class="internal" href="/wiki/Bar">Bar</a></em> buzz</p>\n')
+  })
+
+  it('should render italic bold bracket tags', function () {
+    var text = 'foo ***[[Bar]]*** buzz'
+    expect(Renderer.render(text)).to.be.equal('<p>foo <strong><em><a class="internal" href="/wiki/Bar">Bar</a></em></strong> buzz</p>\n')
+  })
+
   it('should replace {{TOC}} with the table of contents', function () {
     var text = '{{TOC}}\n\n # Heading 1 \n\n This is some text'
     expect(Renderer.render(text)).to.be.equal('<ul>\n<li><p><a href="#heading-1">Heading 1</a></p>\n<h1 id="heading-1">Heading 1</h1>\n<p>This is some text</p>\n</li>\n</ul>\n')


### PR DESCRIPTION
this
```markdown
 any of our **[[communication channels]]**!
```
was producing this

![failing-markup](https://cloud.githubusercontent.com/assets/1596934/21578139/c9ce7984-cf75-11e6-8ea5-45cbdcc67f1c.png)
