### PR TITLE
add the 'absent' class on internal links for missing pages in preview mode too

### DIFF
--- a/public/js/app.js
+++ b/public/js/app.js
@@ -128,24 +128,7 @@
       }
 
       if (/^\/wiki\//.test(window.location.pathname)) {
-        var pages = []
-        var match
-        var href
-
-        $('#content a.internal').each(function (i, a) {
-          href = $(a).attr('href')
-          href = href.slice(proxyPath.length)
-          match = /\/wiki\/(.+)/.exec(href)
-          if (match) {
-            pages.push(decodeURIComponent(match[1]))
-          }
-        })
-
-        $.getJSON(proxyPath + '/misc/existence', {data: pages}, function (result) {
-          $.each(result.data, function (href, a) {
-            $("#content a[href='" + proxyPath.split('/').join('\\/') + '\\/wiki\\/' + encodeURIComponent(a) + "']").addClass('absent')
-          })
-        })
+        markMissingPagesAsAbsent('#content')
       }
 
       function toggleCompareCheckboxes () {
@@ -177,6 +160,7 @@
       $('#preview').modal({keyboard: true, show: true, backdrop: false})
       $.post(proxyPath + '/misc/preview', {data: $('#editor').val()}, function (data) {
         $('#preview .modal-body').html(data).get(0).scrollTop = 0
+        markMissingPagesAsAbsent('#preview .modal-body')
       })
     },
 
@@ -222,6 +206,27 @@
         cheatsheetShown = true
       }
     }
+  }
+
+  function markMissingPagesAsAbsent (selector) {
+    var pages = []
+    var match
+    var href
+
+    $(selector + ' a.internal').each(function (i, a) {
+      href = $(a).attr('href')
+      href = href.slice(proxyPath.length)
+      match = /\/wiki\/(.+)/.exec(href)
+      if (match) {
+        pages.push(decodeURIComponent(match[1]))
+      }
+    })
+
+    $.getJSON(proxyPath + '/misc/existence', {data: pages}, function (result) {
+      $.each(result.data, function (href, a) {
+        $(selector + " a[href='" + proxyPath.split('/').join('\\/') + '\\/wiki\\/' + encodeURIComponent(a) + "']").addClass('absent')
+      })
+    })
   }
 
   window.Jingo = Jingo


### PR DESCRIPTION
can be quite convenient to spot erronous links
![preview with missing link](https://cloud.githubusercontent.com/assets/1596934/21578301/34c9a678-cf7b-11e6-824b-ce567c0aad7b.png)
