### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -247,17 +247,17 @@ Configuration options reference
 
   With this option you can revert this decision if for some reason your documents are not rendered how you like.
 
-####application.gfmBreaks (boolean: true)
+#### application.gfmBreaks (boolean: true)
 
   Enable [GFM line breaks](https://help.github.com/articles/github-flavored-markdown#newlines)
 
-####application.proxyPath (string: "")
+#### application.proxyPath (string: "")
 
   If you want jingo to work "behind" another website (for example in a /wiki directory of an already existing intranet), you need to configure it to be aware of that situation so that it can write all the outbound URLs accordingly. Use this option to pass it the name of the directory that you've configured in your proxy_pass option in nginx or apache. See also an nginx example in the /etc directory of the jingo source distribution.
 
   Please note that jingo won't work correctly if this option is activated.
 
-####authentication.staticWhitelist (string: "/\\.png$/i, /\\.jpg$/i, /\\.gif$/i")
+#### authentication.staticWhitelist (string: "/\\.png$/i, /\\.jpg$/i, /\\.gif$/i")
 
   This is to enable jingo to serve any kind of static file (like images) from the repository. By default, Jingo will serve `*.md` files and `*.jpg, *.png, *.gif`. Provide the values as a comma separated list of regular expressions.
 


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
