### PR TITLE
Fix proxyPath not substituting in login pug for ldap

### DIFF
--- a/views/login.pug
+++ b/views/login.pug
@@ -26,7 +26,7 @@ block content
 
       +errors()
 
-      form.form-horizontal(action='#{proxyPath}/auth/ldap', method='post')
+      form.form-horizontal(action=`${proxyPath}/auth/ldap`, method='post')
         .form-group
           label.col-sm-2.control-label Username
           .col-sm-3


### PR DESCRIPTION
Fix for a small error on login pug that prevents LDAP from posting to the correct endpoint