### PR TITLE
Update LDAP authentication to support binding with user credentials

### DIFF
--- a/routes/auth.js
+++ b/routes/auth.js
@@ -85,15 +85,24 @@ if (auth.github.enabled) {
 }
 
 if (auth.ldap.enabled) {
-  passport.use(new passportLDAP({ // eslint-disable-line new-cap
-    server: {
-      url: auth.ldap.url,
-      bindDn: auth.ldap.bindDn,
-      bindCredentials: auth.ldap.bindCredentials,
-      searchBase: auth.ldap.searchBase,
-      searchFilter: auth.ldap.searchFilter,
-      searchAttributes: auth.ldap.searchAttributes
-    }
+  passport.use(new passportLDAP(function(req, callback) {
+    process.nextTick(function() {
+      var bindDn = auth.ldap.bindDn.replace(/{{username}}/g, req.body.username)
+      var bindCredentials = auth.ldap.bindCredentials.replace(/{{password}}/g, req.body.password)
+
+      var opts = {
+          server: {
+            url: auth.ldap.url,
+            bindDn: bindDn,
+            bindCredentials: bindCredentials,
+            searchBase: auth.ldap.searchBase,
+            searchFilter: auth.ldap.searchFilter,
+            searchAttributes: auth.ldap.searchAttributes
+          }
+      }
+
+      callback(null, opts);
+    })
   },
     function (profile, done) {
       usedAuthentication('ldap')


### PR DESCRIPTION
It's common practice to anonymous binding for LDAP authentication, however the current implementation does not allow enough variance for passing through the user credentials. 

This change allows the `bindDn` and `bindAuthentication` variables to use the same `{{x}}` substitution used by the `searchFilter` further upstream. This method also exposes the username and password fields for easy modification if required by particular non-standard implementations. 

**When not used, there are no changes to existing functionality.**