### PR TITLE
fixed gravatar conditions

### DIFF
--- a/views/history.pug
+++ b/views/history.pug
@@ -18,7 +18,7 @@ block content
           td
             input(type="checkbox", value=item.hashRef)
           td
-            if item.email
+            if config.get('features').gravatar && item.email
               img(src=gravatar().url(item.email, {s:16}))
               |&nbsp;
             |#{item.author}

--- a/views/list.pug
+++ b/views/list.pug
@@ -11,7 +11,7 @@ block content
           div.content.clearfix
             .meta
               |Last update by&nbsp;
-              if item.page.metadata.email && item.page.metadata.email != 'jingouser'
+              if hasGravatar()
                 img(src=gravatar().url(item.page.metadata.email, {s:16}))
               b &nbsp;#{item.page.metadata.author},&nbsp;
               b.date(title=item.page.metadata.date) #{item.page.metadata.relDate}

--- a/views/show.pug
+++ b/views/show.pug
@@ -17,7 +17,7 @@ block content
       !=content
   - var klass = isAjax ? 'jingo-footer' : 'footer'
   p(class=klass) Updated by&nbsp;
-    if page.metadata.email && page.metadata.email != 'jingouser'
+    if hasGravatar()
       img(src=gravatar().url(page.metadata.email, {s:16}))
     b #{page.metadata.author}
     |,&nbsp;


### PR DESCRIPTION
The gravatar opt-out option didn't work on all pages yet. I changed three more files where gravatar is used. Iam not completely sure if the `*.metadata.email` etc. can just be replaced by `hasGravatar()`, but it has similar conditions