### PR TITLE
Authorize email when authenticated via LDAP

### DIFF
--- a/routes/auth.js
+++ b/routes/auth.js
@@ -211,6 +211,7 @@ function _getAuthDone (req, res) {
 
   if (!auth.alone.used &&
       !auth.local.used &&
+      !auth.ldap.used &&
       !tools.isAuthorized(res.locals.user.email,
                           app.locals.config.get('authorization').validMatches,
                           app.locals.config.get('authorization').emptyEmailMatches)) {


### PR DESCRIPTION
When LDAP is used, skip email validation. On a side note, tools.isAuthorized code does not work for new TLD (for example, girish@smartserver.space does not validate in that function).