### PR TITLE
Support login through Mastodon API.

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,7 +145,7 @@ The _authorization_ section of the config file has three keys: `anonRead`, `vali
 
 If `anonRead` is true, then anyone who can access the wiki can read anything. If `anonRead` is false you need to authenticate also for reading and then the email of the user _must_ match at least one of the regular expressions provided via validMatches, which is a comma separated list. There is no "anonWrite", though. To edit a page the user must be authenticated.
 
-`emptyEmailMatches` allows access when remote authentication providers do not provide an email address as part of user data. It defaults to `false`, but will usually need to be set to `true` for GitHub authentication (GitHub only returns email addresses that have been made public on users' GitHub accounts).
+`emptyEmailMatches` allows access when remote authentication providers do not provide an email address as part of user data. It defaults to `false`, but will usually need to be set to `true` for GitHub authentication (GitHub only returns email addresses that have been made public on users' GitHub accounts). It must be set to `true` for Mastodon authentication.
 
 The authentication is mandatory to edit pages from the web interface, but jingo works on a git repository; that means that you could skip the authentication altogether and edit pages with your editor and push to the remote that jingo is serving.
 
@@ -290,7 +290,24 @@ Configuration options reference
 
   Values required for GitHub OAuth2 authentication. Refer to a previous section of this document on how to set them up.
 
-#### authentication.google.redirectUrl (string: /auth/github/callback)
+#### authentication.github.redirectUrl (string: /auth/github/callback)
+
+  Specifies a custom redirect URL for OAuth2 authentication instead of the default
+
+#### authentication.mastodon.enabled (boolean: false)
+
+  Enable or disable authentication via Mastodon logins
+
+#### authentication.mastodon.clientId
+#### authentication.mastodon.clientSecret
+
+  Values required for Mastodon OAuth2 authentication. Refer to a previous section of this document on how to set them up.
+
+#### authentication.mastodon.domain
+
+  Instance of Mastodon used to authenticate logins
+
+#### authentication.mastodon.redirectUrl (string: /auth/mastodon/callback)
 
   Specifies a custom redirect URL for OAuth2 authentication instead of the default
 

--- a/lib/config.js
+++ b/lib/config.js
@@ -76,6 +76,13 @@ module.exports = (function () {
           clientSecret: 'replace me with the real value',
           redirectURL: ''
         },
+        mastodon: {
+          enabled: false,
+          clientId: 'replace me with the real value',
+          clientSecret: 'replace me with the real value',
+          domain: 'your.mastodon.instance',
+          redirectURL: ''
+        },
         ldap: {
           enabled: false,
           url: 'ldap://example.org:389',
@@ -165,6 +172,7 @@ module.exports = (function () {
 
       if (!config.authentication.google.enabled &&
         !config.authentication.github.enabled &&
+        !config.authentication.mastodon.enabled &&
         !config.authentication.ldap.enabled &&
         !config.authentication.alone.enabled &&
         !config.authentication.local.enabled
@@ -180,6 +188,11 @@ module.exports = (function () {
 
       if (config.authentication.github.enabled && (!config.authentication.github.clientId || !config.authentication.github.clientSecret)) {
         error = 'Invalid or missing authentication credentials for Github (clientId and/or clientSecret).'
+        return false
+      }
+
+      if (config.authentication.mastodon.enabled && (!config.authentication.mastodon.clientId || !config.authentication.mastodon.clientSecret || !config.authentication.mastodon.domain)) {
+        error = 'Invalid or missing authentication credentials for Mastodon (clientId and/or clientSecret and/or domain).'
         return false
       }
 

--- a/package.json
+++ b/package.json
@@ -58,6 +58,7 @@
     "passport-github": "^0.1.5",
     "passport-google-oauth": "^0.1.5",
     "passport-local": "^1.0.0",
+    "passport-mastodon": "^0.1.3",
     "pug": "^2.0.0-rc.4",
     "semver": "^5.3.0",
     "serve-favicon": "^2.1.7",

--- a/views/login.pug
+++ b/views/login.pug
@@ -16,7 +16,11 @@ block content
       p
         +anchor('/auth/github', 'Github login').btn-auth.btn-auth-github
 
-    if (auth.google.enabled || auth.github.enabled)
+    if (auth.mastodon.enabled)
+      p
+        +anchor('/auth/mastodon', 'Mastodon login').btn-default
+
+    if (auth.google.enabled || auth.github.enabled || auth.mastodon.enabled)
       p
         +anchor("/", 'Cancel')
 


### PR DESCRIPTION
This commit add Mastdon as an option for login by using mastodon-passport.

Mastodon being a federated social network, there are several instances of the service, so you need to know against which server you do the authentication. In this commit, a domain parameter in the configuration file indicate this.
If users from different instances should be able to log in, this commit must be improved to ask the domain on the login page.

This commit also reorganises a bit the auth.js file by regrouping the code related to a login method inside the same if block. This has the effect of not exposing unneeded API endpoints is those are disabled in the configuration.

This pull request is mainly for reference, as I've seen that you haven't merged similar pull requests.