### PR TITLE
Null-line terminator to support non-latin chars

### DIFF
--- a/lib/gitmech.js
+++ b/lib/gitmech.js
@@ -393,11 +393,11 @@ var gitMech = {
   },
 
   ls: function (pattern, callback) {
-    gitExec([ 'ls-tree', '--name-only', '-r', 'HEAD', '--', docSubdir + pattern ], function (err, data) {
+    gitExec([ 'ls-tree', '--name-only', '-z', '-r', 'HEAD', '--', docSubdir + pattern ], function (err, data) {
       if (err) {
         data = ''
       }
-      callback(null, data.toString().split('\n').filter(function (v) {
+      callback(null, data.toString().split('\0').filter(function (v) {
         return v !== ''
       }))
     })


### PR DESCRIPTION
I've had an issue with non-latin wiki page titles. Default behaviour of git-ls-tree seems to replace certain characters with escape sequences, so it can use `\n` as item breaks safely. It has an option (`-z`) to use `\0` as item separator instead of line-breaks. In that mode it doesn't replace characters.

Here's screenshot how it looks in page listing:

---

![nonlatin](https://user-images.githubusercontent.com/5783792/83939352-e683c980-a7e4-11ea-90e9-817927051ed4.png)

---

With addition of `-z` option characters are not getting replaced by git and links to pages and commit info are become properly displayed.